### PR TITLE
023-auto-refresh

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -68,6 +68,10 @@ div.vega-embed details {
   display: none;
 }
 
+div.toolbar .btn-group {
+  padding-left: 30px;
+}
+
 div.toolbar .mini-button-group {
     font-size: 12px;
     height: 20px;

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -84,6 +84,18 @@ div.toolbar .btn-outline-secondary:focus, .btn-outline-secondary.focus {
     box-shadow:none !important;
 }
 
+span.progress {
+    border-bottom: 0px !important;
+    overflow: hidden;
+    background-color: #ffc107;
+    width: 100%;
+    height: 3px;
+    display: block;
+    top: -2px;
+    position: relative;
+    left: 0px;
+}
+
 div.searchresult > .key {
   color: #333;
   font-size: 14;
@@ -141,3 +153,4 @@ svg.copy-icon:hover {
   padding: 0 11px 0 8px;
   margin-bottom: -10px;
 }
+

--- a/frontend/src/components/WorkflowDetailView.js
+++ b/frontend/src/components/WorkflowDetailView.js
@@ -174,12 +174,13 @@ function WorkflowDetailView({ runArn }) {
     const [nextflowModalData, setNextflowModalData] = useState(false);
     const [nextflowScriptData, setNextflowScriptModalData] = useState(false);
     const [summaryViewSetting, setSummaryViewSetting] = useState("summary"); // "summary" | "json"
+    const [autoRefreshSetting, setAutoRefreshSetting] = useState(true); // true (on) | false (off)
     
     // auto-refresh data
     useInterval(() => {
         runQuery();
         taskQuery();
-    }, 15000)
+    }, autoRefreshSetting ? 15000 : null)
 
     if (runDataIsLoading || taskDataIsLoading) {
         if (!runData || !taskData){ 
@@ -214,6 +215,10 @@ function WorkflowDetailView({ runArn }) {
                 <ToggleButtonGroup type="radio" value={summaryViewSetting} onChange={setSummaryViewSetting} name="summaryViewSettingToggle">
                   <ToggleButton className='mini-button-group' variant="outline-secondary" size="sm" value="summary">Summary</ToggleButton>
                   <ToggleButton className='mini-button-group' variant="outline-secondary" size="sm" value="json">JSON</ToggleButton>
+                </ToggleButtonGroup>
+                <ToggleButtonGroup type="radio" value={autoRefreshSetting} onChange={setAutoRefreshSetting} name="autoRefreshSettingToggle">
+                  <ToggleButton className='mini-button-group' variant="outline-secondary" size="sm" value={true}>Auto-refresh On</ToggleButton>
+                  <ToggleButton className='mini-button-group' variant="outline-secondary" size="sm" value={false}>Off</ToggleButton>
                 </ToggleButtonGroup>
             </div>
         <Row>

--- a/frontend/src/components/WorkflowDetailView.js
+++ b/frontend/src/components/WorkflowDetailView.js
@@ -169,13 +169,13 @@ const StopWorkflowButton = ({aws_status, nf_status, workflow_arn}) => {
 const ProgressBar = ({onDone, isActive}) => {
     const [progressPercentage, setProgressPercentage] = useState(100); 
     useInterval(() => {
-        // will refresh every 10 seconds
+        // will refresh every 30 seconds
         setProgressPercentage(progressPercentage - 1)
         if (progressPercentage <= 0){
             onDone()
             setProgressPercentage(100)
         }
-    }, isActive ? 100 : null)
+    }, isActive ? 300 : null)
 
     return (
         <span 

--- a/frontend/src/components/WorkflowDetailView.js
+++ b/frontend/src/components/WorkflowDetailView.js
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { useQuery } from 'react-fetching-library';
-import { useLocalStorage } from '../hooks.js';
+import { useLocalStorage, useInterval } from '../hooks.js';
 
 import { Link, navigate } from '@reach/router'
 
@@ -168,16 +168,24 @@ const StopWorkflowButton = ({aws_status, nf_status, workflow_arn}) => {
 
 function WorkflowDetailView({ runArn }) {
     document.title = "Workflow Detail"
-    const { loading: runDataIsLoading, payload: runData, error: runDataisError } = useQuery({endpoint: `/api/v1/workflow/${runArn}`, method: 'GET'});
-    const { loading: taskDataIsLoading, payload: taskData, error: taskDataisError } = useQuery({endpoint: `/api/v1/workflow/${runArn}/tasks`, method: 'GET'});
-
+    const { loading: runDataIsLoading, payload: runData, error: runDataisError, query: runQuery } = useQuery({endpoint: `/api/v1/workflow/${runArn}`, method: 'GET'});
+    const { loading: taskDataIsLoading, payload: taskData, error: taskDataisError, query: taskQuery } = useQuery({endpoint: `/api/v1/workflow/${runArn}/tasks`, method: 'GET'});
     const [taskModalData, setTaskModalData] = useState(false);
     const [nextflowModalData, setNextflowModalData] = useState(false);
     const [nextflowScriptData, setNextflowScriptModalData] = useState(false);
     const [summaryViewSetting, setSummaryViewSetting] = useState("summary"); // "summary" | "json"
     
+    // auto-refresh data
+    useInterval(() => {
+        runQuery();
+        taskQuery();
+    }, 15000)
+
     if (runDataIsLoading || taskDataIsLoading) {
-        return <div>Loading</div>
+        if (!runData || !taskData){ 
+            // only display loading state if no data exists
+            return <div>Loading</div>
+        }
     }
     if (runDataisError || taskDataisError) {
         return <div>Error</div>

--- a/frontend/src/hooks.js
+++ b/frontend/src/hooks.js
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 
 function useFetch(url) {
   const [data, setData] = useState([]);
@@ -67,4 +67,26 @@ function useLocalStorage(key, initialValue) {
   return [storedValue, setValue];
 }
 
-export { useFetch, useLocalStorage };
+
+
+function useInterval(callback, delay) {
+  const savedCallback = useRef();
+
+  // Remember the latest callback.
+  useEffect(() => {
+    savedCallback.current = callback;
+  }, [callback]);
+
+  // Set up the interval.
+  useEffect(() => {
+    function tick() {
+      savedCallback.current();
+    }
+    if (delay !== null) {
+      let id = setInterval(tick, delay);
+      return () => clearInterval(id);
+    }
+  }, [delay]);
+}
+
+export { useFetch, useLocalStorage, useInterval };


### PR DESCRIPTION
This closes #23. It adds a little toggle-button to the top of the workflow detail page which displays a countdown indicator and automatically refreshes the data on the page (does not force hard refresh to conserve render). This can be turned off (though default is on for running workflows, off for completed workflows). 